### PR TITLE
added test for improperly formatted request

### DIFF
--- a/TKeazirian.HTTPServer.Tests/Router/MockHandler.cs
+++ b/TKeazirian.HTTPServer.Tests/Router/MockHandler.cs
@@ -4,8 +4,9 @@ namespace TKeazirian.HTTPServer.Tests.Router;
 
 using TKeazirian.HTTPServer.Response;
 using TKeazirian.HTTPServer.Request;
+using Handler;
 
-class MockHandler : Handler.Handler
+class MockHandler : Handler
 {
     public override List<string> AllowedHttpMethods()
     {

--- a/TKeazirian.HTTPServer.Tests/Router/RouterTests.cs
+++ b/TKeazirian.HTTPServer.Tests/Router/RouterTests.cs
@@ -1,24 +1,28 @@
 using System.Collections.Generic;
+using TKeazirian.HTTPServer.Tests.helpers;
 using Xunit;
 
 namespace TKeazirian.HTTPServer.Tests.Router;
 
 using TKeazirian.HTTPServer.Server;
+using TKeazirian.HTTPServer.Request;
+using TKeazirian.HTTPServer.Response;
+using Handler;
 
 public class RouterTests
 {
     [Fact]
     public void RouterRoutesToExpectedHandler()
     {
-        HTTPServer.Request.Request testRequest =
-            new HTTPServer.Request.Request("GET", "/test_path", "", "");
-        var testRoutesConfig = new RoutesConfig(new Dictionary<string, HTTPServer.Handler.Handler>
+        Request testRequest =
+            new Request("GET", "/test_path", "", "");
+        var testRoutesConfig = new RoutesConfig(new Dictionary<string, Handler>
         {
             { "/test_path", new MockHandler() }
         });
         Router router = new Router(testRoutesConfig);
 
-        HTTPServer.Response.Response response = router.Route(testRequest);
+        Response response = router.Route(testRequest);
 
         Assert.Equal("Mock body", response.ResponseBody);
     }
@@ -28,14 +32,14 @@ public class RouterTests
     [InlineData("/")]
     public void ResourceNotFoundHandlerCalledWhenPathIsNotConfigured(string path)
     {
-        HTTPServer.Request.Request testRequest = new HTTPServer.Request.Request("GET", path, "", "");
-        var testRoutesConfig = new RoutesConfig(new Dictionary<string, HTTPServer.Handler.Handler>
+        Request testRequest = new Request("GET", path, "", "");
+        var testRoutesConfig = new RoutesConfig(new Dictionary<string, Handler>
         {
             { "/test_path", new MockHandler() }
         });
         Router router = new Router(testRoutesConfig);
 
-        HTTPServer.Response.Response response = router.Route(testRequest);
+        Response response = router.Route(testRequest);
 
         Assert.Equal("HTTP/1.1 404 Not Found\r\n", response.ResponseStatusLine);
     }
@@ -43,18 +47,30 @@ public class RouterTests
     [Fact]
     public void IfGetMethodIsAllowedOnEndpointThenHeadMethodIsAllowed()
     {
-        HTTPServer.Request.Request testRequest = new HTTPServer.Request.Request("HEAD", "/test_path", "", "");
+        Request testRequest = new Request("HEAD", "/test_path", "", "");
         string testHeaders = "Content-Type: text/plain\r\nContent-Length: 9\r\n\r\n";
-        var testRoutesConfig = new RoutesConfig(new Dictionary<string, HTTPServer.Handler.Handler>
+        var testRoutesConfig = new RoutesConfig(new Dictionary<string, Handler>
         {
             { "/test_path", new MockHandler() }
         });
         Router router = new Router(testRoutesConfig);
 
-        HTTPServer.Response.Response response = router.Route(testRequest);
+        Response response = router.Route(testRequest);
 
         Assert.Equal("HTTP/1.1 200 OK\r\n", response.ResponseStatusLine);
         Assert.Equal(testHeaders, response.ResponseHeaders);
         Assert.Empty(response.GetBody());
+    }
+
+    [Fact]
+    public void IfImproperFormattedRequest404IsCalled()
+    {
+        Request badTestRequest = HelperFunctions.ImproperFormattedRequest("", "GET", "/test_path");
+        Router router = new Router(new RoutesConfig());
+
+        Response response = router.Route(badTestRequest);
+
+        Assert.Equal("HTTP/1.1 404 Not Found\r\n", response.ResponseStatusLine);
+        Assert.Equal("The resource cannot be found", response.ResponseBody);
     }
 }

--- a/TKeazirian.HTTPServer.Tests/helpers/HelperFunctions.cs
+++ b/TKeazirian.HTTPServer.Tests/helpers/HelperFunctions.cs
@@ -1,5 +1,7 @@
 namespace TKeazirian.HTTPServer.Tests.helpers;
 
+using TKeazirian.HTTPServer.Request;
+
 public static class HelperFunctions
 {
     public static string StringTestRequest(string verb, string path, string body = "")
@@ -19,5 +21,11 @@ public static class HelperFunctions
             $"Content-Length: 11{Constants.NewLine}{Constants.NewLine}";
 
         return testResponseHeaders;
+    }
+
+    public static Request ImproperFormattedRequest(string verb, string path, string body)
+    {
+        Request testRequest = new Request(body, verb, CreateTestResponseHeaders(), path);
+        return testRequest;
     }
 }


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/ebeR4cw9/49-reminder-add-missing-degenerate-tests)

Added a test (and reformatted some `using` statements) for the improperly formatted request to expect 404 Not Found